### PR TITLE
fix: scrolling back to element top on collapse

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# EditorConfig is awesome: https://EditorConfig.org
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*.{js,py,tsx,jsx,ts}]
+charset = utf-8
+indent_size = 2
+indent_style = space

--- a/packages/docs/components/Expandable.tsx
+++ b/packages/docs/components/Expandable.tsx
@@ -10,9 +10,26 @@ const Expandable = ({ children }) => {
     const scrollTop = window.scrollY || document.documentElement.scrollTop;
     const elementTop = rect.top + scrollTop;
     const paddingTop = 100;
-    window.scrollTo({
-      top: elementTop - paddingTop,
-    });
+
+    const start = performance.now();
+    const duration = 500; // Adjust the duration as desired
+
+    const animateScroll = (timestamp) => {
+      const elapsed = timestamp - start;
+      const progress = Math.min(elapsed / duration, 1);
+      const scrollTop = elementTop - paddingTop * progress;
+
+      window.scrollTo({
+        top: scrollTop,
+        behavior: "auto",
+      });
+
+      if (progress < 1) {
+        window.requestAnimationFrame(animateScroll);
+      }
+    };
+
+    window.requestAnimationFrame(animateScroll);
   };
 
   const toggleExpand = () => {

--- a/packages/docs/components/Expandable.tsx
+++ b/packages/docs/components/Expandable.tsx
@@ -1,56 +1,64 @@
 import clsx from "clsx";
-import { useState, useRef} from "react";
+import { useRef, useState } from "react";
 
 const Expandable = ({ children }) => {
-    const [expanded, setExpanded] = useState(false);
-    const containerRef = useRef(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [expanded, setExpanded] = useState(false);
 
-    const toggleExpand = () => {
+  const scrollToElement = () => {
+    const rect = containerRef.current.getBoundingClientRect();
+    const scrollTop = window.scrollY || document.documentElement.scrollTop;
+    const elementTop = rect.top + scrollTop;
+    const paddingTop = 100;
+    window.scrollTo({
+      top: elementTop - paddingTop,
+    });
+  };
+
+  const toggleExpand = () => {
+    if (expanded) scrollToElement();
     setExpanded(!expanded);
-    if (!expanded) {
-        containerRef.current.scrollIntoView({ behavior: "smooth" });
-        }
-    };
+  };
 
-    const styles = {
-        collapsed: {
-            height: "200px",
-            WebkitMaskImage: `linear-gradient(rgba(0, 0, 0, 1) 65%, transparent 100%)`,
-            maskImage: `linear-gradient(rgba(0, 0, 0, 1) 65%, transparent 100%)`,
-        },
-        expanded: {
-            height: "auto",
-        },
-    };
+  const styles = {
+    collapsed: {
+      height: "200px",
+      WebkitMaskImage: `linear-gradient(rgba(0, 0, 0, 1) 65%, transparent 100%)`,
+      maskImage: `linear-gradient(rgba(0, 0, 0, 1) 65%, transparent 100%)`,
+    },
+    expanded: {
+      height: "auto",
+    },
+  };
 
-return (
-        <div className="nx-mt-4 nx-mb-12 nx-relative" ref={containerRef}>
-            <div
-            className={clsx("nx-w-full nx-overflow-hidden")}
-            style={expanded ? styles.expanded : styles.collapsed}
-            >
-            {children}
-            </div>
+  return (
+    <div ref={containerRef} className="nx-mt-4 nx-mb-12 nx-relative">
+      <div
+        className={clsx("nx-w-full nx-overflow-hidden")}
+        style={expanded ? styles.expanded : styles.collapsed}
+      >
+        {children}
+      </div>
 
-            <button
-            onClick={toggleExpand}
-            style={{ bottom: expanded ? "-0.2em" : "-1.35em" }}
-            className={clsx(
-                "nx-absolute nx-w-full nx-text-center nx-left-0",
-                "nx-uppercase nx-text-sm"
-            )}
-            >
-            <span
-                className={clsx(
-                "nx-px-4 nx-py-2 nx-text-primary-800 nx-inline-block",
-                "nx-bg-primary-100 dark:nx-bg-primary-400/10 nx-font-semibold nx-rounded"
-                )}
-            >
-                {expanded ? "Collapse" : "Expand"}
-            </span>
-            </button>
-        </div>
-    );
+      <button
+        onClick={toggleExpand}
+        style={{ bottom: expanded ? "-0.2em" : "-1.35em" }}
+        className={clsx(
+          "nx-absolute nx-w-full nx-text-center nx-left-0",
+          "nx-uppercase nx-text-sm"
+        )}
+      >
+        <span
+          className={clsx(
+            "nx-px-4 nx-py-2 nx-text-primary-800 nx-inline-block",
+            "nx-bg-primary-100 dark:nx-bg-primary-400/10 nx-font-semibold nx-rounded"
+          )}
+        >
+          {expanded ? "Collapse" : "Expand"}
+        </span>
+      </button>
+    </div>
+  );
 };
 
 export default Expandable;

--- a/packages/docs/components/Expandable.tsx
+++ b/packages/docs/components/Expandable.tsx
@@ -2,80 +2,65 @@ import clsx from "clsx";
 import { useRef, useState } from "react";
 
 const Expandable = ({ children }) => {
-    const containerRef = useRef<HTMLDivElement>(null);
-    const [expanded, setExpanded] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [expanded, setExpanded] = useState(false);
 
-    const scrollToElement = () => {
-        const rect = containerRef.current.getBoundingClientRect();
-        const scrollTop = window.scrollY || document.documentElement.scrollTop;
-        const elementTop = rect.top + scrollTop;
-        const paddingTop = 100;
+  const scrollToElement = () => {
+    const rect = containerRef.current.getBoundingClientRect();
+    const scrollTop = window.scrollY || document.documentElement.scrollTop;
+    const elementTop = rect.top + scrollTop;
+    const paddingTop = 100;
 
-        const start = performance.now();
-        const duration = 500; // Adjust the duration as desired
+    window.scrollTo({
+      top: elementTop - paddingTop,
+      behavior: "smooth",
+    });
+  };
 
-        const animateScroll = (timestamp) => {
-        const elapsed = timestamp - start;
-        const progress = Math.min(elapsed / duration, 1);
-        const scrollTop = elementTop - paddingTop * progress;
+  const toggleExpand = () => {
+    if (expanded) scrollToElement();
+    setExpanded(!expanded);
+  };
 
-        window.scrollTo({
-            top: scrollTop,
-            behavior: "auto",
-        });
+  const styles = {
+    collapsed: {
+      height: "200px",
+      WebkitMaskImage: `linear-gradient(rgba(0, 0, 0, 1) 65%, transparent 100%)`,
+      maskImage: `linear-gradient(rgba(0, 0, 0, 1) 65%, transparent 100%)`,
+    },
+    expanded: {
+      height: "auto",
+    },
+  };
 
-        if (progress < 1) {
-            window.requestAnimationFrame(animateScroll);
-        }
-        };
+  return (
+    <div ref={containerRef} className="nx-mt-4 nx-mb-12 nx-relative">
+      <div
+        className={clsx("nx-w-full nx-overflow-hidden")}
+        style={expanded ? styles.expanded : styles.collapsed}
+      >
+        {children}
+      </div>
 
-        window.requestAnimationFrame(animateScroll);
-    };
-
-    const toggleExpand = () => {
-        if (expanded) scrollToElement();
-        setExpanded(!expanded);
-    };
-
-    const styles = {
-        collapsed: {
-        height: "200px",
-        WebkitMaskImage: `linear-gradient(rgba(0, 0, 0, 1) 65%, transparent 100%)`,
-        maskImage: `linear-gradient(rgba(0, 0, 0, 1) 65%, transparent 100%)`,
-        },
-        expanded: {
-        height: "auto",
-        },
-    };
-
-    return (
-        <div ref={containerRef} className="nx-mt-4 nx-mb-12 nx-relative">
-        <div
-            className={clsx("nx-w-full nx-overflow-hidden")}
-            style={expanded ? styles.expanded : styles.collapsed}
+      <button
+        onClick={toggleExpand}
+        style={{ bottom: expanded ? "-0.2em" : "-1.35em" }}
+        className={clsx(
+          "nx-absolute nx-w-full nx-text-center nx-left-0",
+          "nx-uppercase nx-text-sm"
+        )}
+      >
+        <span
+          className={clsx(
+            "nx-px-4 nx-py-2 nx-text-primary-800 nx-inline-block",
+            "nx-bg-primary-100 dark:nx-bg-primary-400/10 nx-font-semibold nx-rounded"
+          )}
         >
-            {children}
-        </div>
-
-        <button
-            onClick={toggleExpand}
-            style={{ bottom: expanded ? "-0.2em" : "-1.35em" }}
-            className={clsx(
-            "nx-absolute nx-w-full nx-text-center nx-left-0",
-            "nx-uppercase nx-text-sm"
-            )}
-        >
-            <span
-            className={clsx(
-                "nx-px-4 nx-py-2 nx-text-primary-800 nx-inline-block",
-                "nx-bg-primary-100 dark:nx-bg-primary-400/10 nx-font-semibold nx-rounded"
-            )}
-            >
-            {expanded ? "Collapse" : "Expand"}
-            </span>
-        </button>
-        </div>
-    );
+          {expanded ? "Collapse" : "Expand"}
+        </span>
+      </button>
+    </div>
+  );
 };
 
 export default Expandable;

--- a/packages/docs/components/Expandable.tsx
+++ b/packages/docs/components/Expandable.tsx
@@ -2,80 +2,80 @@ import clsx from "clsx";
 import { useRef, useState } from "react";
 
 const Expandable = ({ children }) => {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [expanded, setExpanded] = useState(false);
+    const containerRef = useRef<HTMLDivElement>(null);
+    const [expanded, setExpanded] = useState(false);
 
-  const scrollToElement = () => {
-    const rect = containerRef.current.getBoundingClientRect();
-    const scrollTop = window.scrollY || document.documentElement.scrollTop;
-    const elementTop = rect.top + scrollTop;
-    const paddingTop = 100;
+    const scrollToElement = () => {
+        const rect = containerRef.current.getBoundingClientRect();
+        const scrollTop = window.scrollY || document.documentElement.scrollTop;
+        const elementTop = rect.top + scrollTop;
+        const paddingTop = 100;
 
-    const start = performance.now();
-    const duration = 500; // Adjust the duration as desired
+        const start = performance.now();
+        const duration = 500; // Adjust the duration as desired
 
-    const animateScroll = (timestamp) => {
-      const elapsed = timestamp - start;
-      const progress = Math.min(elapsed / duration, 1);
-      const scrollTop = elementTop - paddingTop * progress;
+        const animateScroll = (timestamp) => {
+        const elapsed = timestamp - start;
+        const progress = Math.min(elapsed / duration, 1);
+        const scrollTop = elementTop - paddingTop * progress;
 
-      window.scrollTo({
-        top: scrollTop,
-        behavior: "auto",
-      });
+        window.scrollTo({
+            top: scrollTop,
+            behavior: "auto",
+        });
 
-      if (progress < 1) {
+        if (progress < 1) {
+            window.requestAnimationFrame(animateScroll);
+        }
+        };
+
         window.requestAnimationFrame(animateScroll);
-      }
     };
 
-    window.requestAnimationFrame(animateScroll);
-  };
+    const toggleExpand = () => {
+        if (expanded) scrollToElement();
+        setExpanded(!expanded);
+    };
 
-  const toggleExpand = () => {
-    if (expanded) scrollToElement();
-    setExpanded(!expanded);
-  };
+    const styles = {
+        collapsed: {
+        height: "200px",
+        WebkitMaskImage: `linear-gradient(rgba(0, 0, 0, 1) 65%, transparent 100%)`,
+        maskImage: `linear-gradient(rgba(0, 0, 0, 1) 65%, transparent 100%)`,
+        },
+        expanded: {
+        height: "auto",
+        },
+    };
 
-  const styles = {
-    collapsed: {
-      height: "200px",
-      WebkitMaskImage: `linear-gradient(rgba(0, 0, 0, 1) 65%, transparent 100%)`,
-      maskImage: `linear-gradient(rgba(0, 0, 0, 1) 65%, transparent 100%)`,
-    },
-    expanded: {
-      height: "auto",
-    },
-  };
-
-  return (
-    <div ref={containerRef} className="nx-mt-4 nx-mb-12 nx-relative">
-      <div
-        className={clsx("nx-w-full nx-overflow-hidden")}
-        style={expanded ? styles.expanded : styles.collapsed}
-      >
-        {children}
-      </div>
-
-      <button
-        onClick={toggleExpand}
-        style={{ bottom: expanded ? "-0.2em" : "-1.35em" }}
-        className={clsx(
-          "nx-absolute nx-w-full nx-text-center nx-left-0",
-          "nx-uppercase nx-text-sm"
-        )}
-      >
-        <span
-          className={clsx(
-            "nx-px-4 nx-py-2 nx-text-primary-800 nx-inline-block",
-            "nx-bg-primary-100 dark:nx-bg-primary-400/10 nx-font-semibold nx-rounded"
-          )}
+    return (
+        <div ref={containerRef} className="nx-mt-4 nx-mb-12 nx-relative">
+        <div
+            className={clsx("nx-w-full nx-overflow-hidden")}
+            style={expanded ? styles.expanded : styles.collapsed}
         >
-          {expanded ? "Collapse" : "Expand"}
-        </span>
-      </button>
-    </div>
-  );
+            {children}
+        </div>
+
+        <button
+            onClick={toggleExpand}
+            style={{ bottom: expanded ? "-0.2em" : "-1.35em" }}
+            className={clsx(
+            "nx-absolute nx-w-full nx-text-center nx-left-0",
+            "nx-uppercase nx-text-sm"
+            )}
+        >
+            <span
+            className={clsx(
+                "nx-px-4 nx-py-2 nx-text-primary-800 nx-inline-block",
+                "nx-bg-primary-100 dark:nx-bg-primary-400/10 nx-font-semibold nx-rounded"
+            )}
+            >
+            {expanded ? "Collapse" : "Expand"}
+            </span>
+        </button>
+        </div>
+    );
 };
 
 export default Expandable;


### PR DESCRIPTION
Quick fix on <Expandable /> component. Now when the user collapses the panel, window scrolls to the top of the container.