### PR TITLE
Fixing Warnings on Dev Mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "license": "GPL-3.0",
       "workspaces": [
         "packages/docs",
         "packages/specs"
@@ -278,14 +279,14 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "13.4.7",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.7.tgz",
-      "integrity": "sha512-ZlbiFulnwiFsW9UV1ku1OvX/oyIPLtMk9p/nnvDSwI0s7vSoZdRtxXNsaO+ZXrLv/pMbXVGq4lL8TbY9iuGmVw=="
+      "version": "13.4.10",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.10.tgz",
+      "integrity": "sha512-3G1yD/XKTSLdihyDSa8JEsaWOELY+OWe08o0LUYzfuHp1zHDA8SObQlzKt+v+wrkkPcnPweoLH1ImZeUa0A1NQ=="
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "13.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.7.tgz",
-      "integrity": "sha512-VZTxPv1b59KGiv/pZHTO5Gbsdeoxcj2rU2cqJu03btMhHpn3vwzEK0gUSVC/XW96aeGO67X+cMahhwHzef24/w==",
+      "version": "13.4.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.10.tgz",
+      "integrity": "sha512-4bsdfKmmg7mgFGph0UorD1xWfZ5jZEw4kKRHYEeTK9bT1QnMbPVPlVXQRIiFPrhoDQnZUoa6duuPUJIEGLV1Jg==",
       "cpu": [
         "arm64"
       ],
@@ -298,9 +299,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "13.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.7.tgz",
-      "integrity": "sha512-gO2bw+2Ymmga+QYujjvDz9955xvYGrWofmxTq7m70b9pDPvl7aDFABJOZ2a8SRCuSNB5mXU8eTOmVVwyp/nAew==",
+      "version": "13.4.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.10.tgz",
+      "integrity": "sha512-ngXhUBbcZIWZWqNbQSNxQrB9T1V+wgfCzAor2olYuo/YpaL6mUYNUEgeBMhr8qwV0ARSgKaOp35lRvB7EmCRBg==",
       "cpu": [
         "x64"
       ],
@@ -313,9 +314,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "13.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.7.tgz",
-      "integrity": "sha512-6cqp3vf1eHxjIDhEOc7Mh/s8z1cwc/l5B6ZNkOofmZVyu1zsbEM5Hmx64s12Rd9AYgGoiCz4OJ4M/oRnkE16/Q==",
+      "version": "13.4.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.10.tgz",
+      "integrity": "sha512-SjCZZCOmHD4uyM75MVArSAmF5Y+IJSGroPRj2v9/jnBT36SYFTORN8Ag/lhw81W9EeexKY/CUg2e9mdebZOwsg==",
       "cpu": [
         "arm64"
       ],
@@ -328,9 +329,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "13.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.7.tgz",
-      "integrity": "sha512-T1kD2FWOEy5WPidOn1si0rYmWORNch4a/NR52Ghyp4q7KyxOCuiOfZzyhVC5tsLIBDH3+cNdB5DkD9afpNDaOw==",
+      "version": "13.4.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.10.tgz",
+      "integrity": "sha512-F+VlcWijX5qteoYIOxNiBbNE8ruaWuRlcYyIRK10CugqI/BIeCDzEDyrHIHY8AWwbkTwe6GRHabMdE688Rqq4Q==",
       "cpu": [
         "arm64"
       ],
@@ -343,9 +344,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "13.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.7.tgz",
-      "integrity": "sha512-zaEC+iEiAHNdhl6fuwl0H0shnTzQoAoJiDYBUze8QTntE/GNPfTYpYboxF5LRYIjBwETUatvE0T64W6SKDipvg==",
+      "version": "13.4.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.10.tgz",
+      "integrity": "sha512-WDv1YtAV07nhfy3i1visr5p/tjiH6CeXp4wX78lzP1jI07t4PnHHG1WEDFOduXh3WT4hG6yN82EQBQHDi7hBrQ==",
       "cpu": [
         "x64"
       ],
@@ -358,9 +359,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "13.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.7.tgz",
-      "integrity": "sha512-X6r12F8d8SKAtYJqLZBBMIwEqcTRvUdVm+xIq+l6pJqlgT2tNsLLf2i5Cl88xSsIytBICGsCNNHd+siD2fbWBA==",
+      "version": "13.4.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.10.tgz",
+      "integrity": "sha512-zFkzqc737xr6qoBgDa3AwC7jPQzGLjDlkNmt/ljvQJ/Veri5ECdHjZCUuiTUfVjshNIIpki6FuP0RaQYK9iCRg==",
       "cpu": [
         "x64"
       ],
@@ -373,9 +374,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "13.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.7.tgz",
-      "integrity": "sha512-NPnmnV+vEIxnu6SUvjnuaWRglZzw4ox5n/MQTxeUhb5iwVWFedolPFebMNwgrWu4AELwvTdGtWjqof53AiWHcw==",
+      "version": "13.4.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.10.tgz",
+      "integrity": "sha512-IboRS8IWz5mWfnjAdCekkl8s0B7ijpWeDwK2O8CdgZkoCDY0ZQHBSGiJ2KViAG6+BJVfLvcP+a2fh6cdyBr9QQ==",
       "cpu": [
         "arm64"
       ],
@@ -388,9 +389,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "13.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.7.tgz",
-      "integrity": "sha512-6Hxijm6/a8XqLQpOOf/XuwWRhcuc/g4rBB2oxjgCMuV9Xlr2bLs5+lXyh8w9YbAUMYR3iC9mgOlXbHa79elmXw==",
+      "version": "13.4.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.10.tgz",
+      "integrity": "sha512-bSA+4j8jY4EEiwD/M2bol4uVEu1lBlgsGdvM+mmBm/BbqofNBfaZ2qwSbwE2OwbAmzNdVJRFRXQZ0dkjopTRaQ==",
       "cpu": [
         "ia32"
       ],
@@ -403,9 +404,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "13.4.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.7.tgz",
-      "integrity": "sha512-sW9Yt36Db1nXJL+mTr2Wo0y+VkPWeYhygvcHj1FF0srVtV+VoDjxleKtny21QHaG05zdeZnw2fCtf2+dEqgwqA==",
+      "version": "13.4.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.10.tgz",
+      "integrity": "sha512-g2+tU63yTWmcVQKDGY0MV1PjjqgZtwM4rB1oVVi/v0brdZAcrcTV+04agKzWtvWroyFz6IqtT0MoZJA7PNyLVw==",
       "cpu": [
         "x64"
       ],
@@ -3050,11 +3051,11 @@
       }
     },
     "node_modules/next": {
-      "version": "13.4.7",
-      "resolved": "https://registry.npmjs.org/next/-/next-13.4.7.tgz",
-      "integrity": "sha512-M8z3k9VmG51SRT6v5uDKdJXcAqLzP3C+vaKfLIAM0Mhx1um1G7MDnO63+m52qPdZfrTFzMZNzfsgvm3ghuVHIQ==",
+      "version": "13.4.10",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.4.10.tgz",
+      "integrity": "sha512-4ep6aKxVTQ7rkUW2fBLhpBr/5oceCuf4KmlUpvG/aXuDTIf9mexNSpabUD6RWPspu6wiJJvozZREhXhueYO36A==",
       "dependencies": {
-        "@next/env": "13.4.7",
+        "@next/env": "13.4.10",
         "@swc/helpers": "0.5.1",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001406",
@@ -3070,15 +3071,15 @@
         "node": ">=16.8.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "13.4.7",
-        "@next/swc-darwin-x64": "13.4.7",
-        "@next/swc-linux-arm64-gnu": "13.4.7",
-        "@next/swc-linux-arm64-musl": "13.4.7",
-        "@next/swc-linux-x64-gnu": "13.4.7",
-        "@next/swc-linux-x64-musl": "13.4.7",
-        "@next/swc-win32-arm64-msvc": "13.4.7",
-        "@next/swc-win32-ia32-msvc": "13.4.7",
-        "@next/swc-win32-x64-msvc": "13.4.7"
+        "@next/swc-darwin-arm64": "13.4.10",
+        "@next/swc-darwin-x64": "13.4.10",
+        "@next/swc-linux-arm64-gnu": "13.4.10",
+        "@next/swc-linux-arm64-musl": "13.4.10",
+        "@next/swc-linux-x64-gnu": "13.4.10",
+        "@next/swc-linux-x64-musl": "13.4.10",
+        "@next/swc-win32-arm64-msvc": "13.4.10",
+        "@next/swc-win32-ia32-msvc": "13.4.10",
+        "@next/swc-win32-x64-msvc": "13.4.10"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -4180,8 +4181,9 @@
     "packages/docs": {
       "name": "namada-docs",
       "version": "0.0.1",
+      "license": "GPL-3.0",
       "dependencies": {
-        "next": "^13.0.6",
+        "next": "^13.4.8",
         "nextra": "latest",
         "nextra-theme-docs": "latest",
         "react": "^18.2.0",
@@ -4195,8 +4197,9 @@
     "packages/specs": {
       "name": "namada-specs",
       "version": "0.0.1",
+      "license": "GPL-3.0",
       "dependencies": {
-        "next": "^13.0.6",
+        "next": "^13.4.8",
         "nextra": "latest",
         "nextra-theme-docs": "latest",
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "license": "GPL-3.0",
   "workspaces": [
     "packages/docs",
     "packages/specs"

--- a/packages/docs/components/Logo.tsx
+++ b/packages/docs/components/Logo.tsx
@@ -52,9 +52,9 @@ export const Logo = () => {
           x="191"
           y="105.4"
           fill={fill}
-          font-family='SpaceGrotesk-Medium,"Space Grotesk"'
-          font-size="77.8"
-          font-weight="500"
+          fontFamily='SpaceGrotesk-Medium,"Space Grotesk"'
+          fontSize="77.8"
+          fontWeight="500"
         >
           <tspan id="tspan150" x="191" y="105.4">
             DOCS

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -9,7 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "^13.0.6",
+    "next": "^13.4.8",
     "nextra": "latest",
     "nextra-theme-docs": "latest",
     "react": "^18.2.0",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -2,6 +2,7 @@
   "name": "namada-docs",
   "version": "0.0.1",
   "description": "Namada Specs",
+  "license": "GPL-3.0",
   "scripts": {
     "dev": "next dev",
     "build": "next build && next export",

--- a/packages/docs/pages/_app.mdx
+++ b/packages/docs/pages/_app.mdx
@@ -1,6 +1,5 @@
 import "../global.css";
 
-// This default export is required in a new `pages/_app.js` file.
 export default function Docs({ Component, pageProps }) {
   return <Component {...pageProps} />;
 }

--- a/packages/specs/components/Logo.jsx
+++ b/packages/specs/components/Logo.jsx
@@ -52,7 +52,7 @@ export const Logo = () => {
           fill={fill}
           fontFamily='SpaceGrotesk-Medium,"Space Grotesk"'
           fontSize="77.8"
-          font-weight="500"
+          fontWeight="500"
         >
           <tspan id="tspan150" x="191" y="105.4">
             SPECS

--- a/packages/specs/package.json
+++ b/packages/specs/package.json
@@ -9,7 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "^13.0.6",
+    "next": "^13.4.8",
     "nextra": "latest",
     "nextra-theme-docs": "latest",
     "react": "^18.2.0",

--- a/packages/specs/package.json
+++ b/packages/specs/package.json
@@ -2,6 +2,7 @@
   "name": "namada-specs",
   "version": "0.0.1",
   "description": "Namada Docs",
+  "license": "GPL-3.0",
   "scripts": {
     "dev": "next dev",
     "build": "next build && next export",

--- a/packages/specs/pages/_app.mdx
+++ b/packages/specs/pages/_app.mdx
@@ -1,6 +1,5 @@
 import "../global.css";
 
-// This default export is required in a new `pages/_app.js` file.
 export default function Specs({ Component, pageProps }) {
   return <Component {...pageProps} />;
 }


### PR DESCRIPTION
This PR fixes the following warnings:
- Invalid React properties on Logo SVGs
- ```Parsing of <path>nextra/dist/plugin.mjs for build dependencies failed at 'import(importPath)'. Build dependencies behind this expression are ignored and might cause incorrect cache invalidation```
- ```[nextra] Found "_app.jsx" file, refactor it to "_app.mdx" for better performance.```
- ```warning package.json: No license field```