### PR TITLE
Replacing spa-to-http by Nginx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,19 +22,14 @@ ENV NEXT_TELEMETRY_DISABLED 1
 RUN npm run build:${TARGET}
 
 # Production image, copy all the files and run next
-FROM devforth/spa-to-http:latest
+FROM nginx:alpine
 
 ARG TARGET
-
-WORKDIR /app
-
-RUN addgroup --system --gid 1001 nodejs
-RUN adduser --system --uid 1001 nextjs
-
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+WORKDIR /usr/share/nginx/html
+RUN rm -rf ./*
 COPY --from=builder /app/packages/${TARGET}/out .
-
-USER nextjs
 
 EXPOSE 3000
 
-ENV PORT 3000
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,12 @@
+server {
+   listen 3000;
+   root /usr/share/nginx/html;
+   location /_next/static {
+     # Provides caching for static assets, to improve server performance
+     add_header Cache-Control "max-age=31536000";
+   }
+   location / {
+     try_files $uri.html  $uri $uri/ /index.html;
+     add_header Cache-Control "no-cache";
+   }
+ }


### PR DESCRIPTION
This PR intends to fix an error happening when users refresh a subpath of Namada docs, being redirected to index page.

In order to fix this issue, we're replacing `spa-to-http` by a custom Nginx config, located at `/nginx.config` . 