### PR TITLE
Fixing Namada community url

### DIFF
--- a/packages/specs/pages/further-reading.mdx
+++ b/packages/specs/pages/further-reading.mdx
@@ -4,7 +4,7 @@ Thanks for reading! You can find further information about the project below:
 
 - [Namada website](https://namada.net)
 - [Namada source code](https://github.com/anoma/namada)
-- [Namada community links](https://namada.net/community)
+- [Namada community links](https://namada.net/#community)
 - [Namada blog](https://blog.namada.net)
 - [Namada Docs](https://docs.namada.net/)
 - [Namada Twitter](https://twitter.com/namadanetwork)


### PR DESCRIPTION
Namada Community is not a page (yet). Fixing the URL to point to our community section (anchor). 