### PR TITLE
Reducing collapse level for sidebar

### DIFF
--- a/packages/docs/theme.config.tsx
+++ b/packages/docs/theme.config.tsx
@@ -15,6 +15,9 @@ const config: DocsThemeConfig = {
       canonical: "https://docs.namada.net",
     };
   },
+  sidebar: {
+    defaultMenuCollapseLevel: 1,
+  },
   head: <PageHead />,
   logo: <Logo />,
   project: {

--- a/packages/specs/theme.config.tsx
+++ b/packages/specs/theme.config.tsx
@@ -23,6 +23,9 @@ const config: DocsThemeConfig = {
   chat: {
     link: "https://discord.gg/namada",
   },
+  sidebar: {
+    defaultMenuCollapseLevel: 1,
+  },
   docsRepositoryBase:
     "https://github.com/anoma/namada-docs/blob/master/packages/specs",
   footer: {


### PR DESCRIPTION
The default collapse level for the sidebar hierarchy is 2. This setting lowers it to 1, in order to reduce the initial sidebar height.