### PR TITLE
feat(community): setting basePath for community docs

### DIFF
--- a/packages/community/components/PageHead.tsx
+++ b/packages/community/components/PageHead.tsx
@@ -4,12 +4,12 @@ export const PageHead = () => {
       <meta name="viewport" content="width=device-width, initial-scale=1" />
       <meta
         property="og:image"
-        content="https://community.namada.net/opengraph.png"
+        content="https://namada.net/community/docs/opengraph.png"
       />
       <meta name="twitter:card" content="summary_large_image" />
       <meta name="twitter:site" content="@namada" />
       <meta name="twitter:creator" content="@namada" />
-      <meta property="og:url" content="https://community.namada.net" />
+      <meta property="og:url" content="https://namada.net/community/docs" />
       <link rel="icon" type="image/x-icon" href="/favicon.ico" />
       <link
         rel="icon"

--- a/packages/community/next.config.js
+++ b/packages/community/next.config.js
@@ -7,6 +7,7 @@ const withNextra = require("nextra")({
 
 module.exports = {
   ...withNextra(),
+  basePath: "/community/docs",
   images: {
     unoptimized: true,
   },


### PR DESCRIPTION
We've set a reverse proxy from namada.net/community/docs to the Community site. According to [NextJS docs](https://nextjs.org/docs/pages/building-your-application/deploying/multi-zones), I'm just setting the `basePath` setting to make it work properly with the site assets. 