### PR TITLE
Update testnet-history.mdx

### DIFF
--- a/packages/docs/pages/networks/testnets/testnet-history.mdx
+++ b/packages/docs/pages/networks/testnets/testnet-history.mdx
@@ -20,7 +20,7 @@ Then, simply stop the current ledger and restart it with the new binaries. This 
 ```bash copy
 OS="Linux" # Or OS="Darwin" for Mac
 wget https://github.com/anoma/namada/releases/download/v0.23.1/namada-v0.23.1-${OS}-x86_64.tar.gz
-tar -xvf namada-v0.23.1-${OS}-x86_64.tar.gz -C /usr/local/bin/ #sudo may be required
+tar -xvf namada-v0.23.1-${OS}-x86_64.tar.gz --strip-components 1 -C /usr/local/bin/ #sudo may be required
 killall namadan
 namada --version #should output v0.23.1
 NAMADA_CMT_STDOUT=true namada node ledger run


### PR DESCRIPTION
the binaries should be extracted without a subfolder