### PR TITLE
Set `CMT_LOG_LEVEL` in SystemD service unit

### DIFF
--- a/packages/docs/pages/operators/ledger/running-a-full-node.mdx
+++ b/packages/docs/pages/operators/ledger/running-a-full-node.mdx
@@ -45,7 +45,7 @@ After=network-online.target
 [Service]
 User=$USER
 WorkingDirectory=$HOME/.local/share/namada
-Environment=TM_LOG_LEVEL=p2p:none,pex:error
+Environment=CMT_LOG_LEVEL=p2p:none,pex:error
 Environment=NAMADA_CMT_STDOUT=true
 ExecStart=/usr/local/bin/namada node ledger run 
 StandardOutput=syslog


### PR DESCRIPTION
dcd41bf77ddc432fcced9c8ca4721f889a78b06b added instructions for setting up a SystemD service unit. However, they configure a `TM_LOG_LEVEL` env variable. This does not appear to get the job done.

As per [`operators/ledger/logging-config.mdx`](https://github.com/anoma/namada-docs/blob/f5c3b6f56d6bc846d9624b542c216a8d6cbde4aa/packages/docs/pages/operators/ledger/logging-config.mdx), the `CMT_LOG_LEVEL` env variable actually controls CometBFT logging verbosity. This PR sets the SystemD unit up with this correct environment variable name.