### PR TITLE
Add `Abstain` vote option in governance

### DIFF
--- a/packages/specs/pages/governance.mdx
+++ b/packages/specs/pages/governance.mdx
@@ -3,12 +3,15 @@ import { Callout } from 'nextra-theme-docs'
 # Governance
 
 ## Definitions
+
 Before describing Namada governance, it is useful to define the concepts of NAM, validators, delegators, and delegates.
 
 *Cryptoeconomic terminology*
+
 > Namada's economic model is based around a single native token, **NAM**, which is controlled by the protocol.
 
 *Consensus terminology*
+
 > A Namada **validator** is an account with a public consensus key, which may participate in producing blocks and governance activities. A validator may not also be a **delegator** (although, of course, a user can control both validator and delegator keys).
 
 #### Delegation in terms of ***consensus***:
@@ -21,16 +24,21 @@ The validator's voting-power is proportional to the sum of its self-bonded token
 With the above definitions in mind, we define the following terms:
 
 > A Namada ***delegator*** is an account that delegates some tokens to a _delegate_ for governance voting purposes. 
+
 Any address is either a delegator or a delegate, but not both.
 
 > A Namada ***delegate*** is an account that has been given the right to vote on the behalf of a delegator. 
+
 A delegate may not also be a delegator.
 
 When an address bonds tokens, the address is able to specify a *delegate*. 
 The respective validator of that address becomes the default *delegate* (explained below) of that address. 
 Similarly, a delegate's `voting-power` (now in terms of voting on governance proposals, not blocks) is proportional to the sum of its self-bonded tokens and all the bonded tokens from other addresses to their own address.
 
+> **Note**: Initially, Namada only supports validators as delegates. In the future, the ability for separate delegates may be added.
+
 ## Motivation
+
 Namada introduces a governance mechanism to propose and apply protocol changes without the need for a hard fork, and to signal stakeholder approval for potential hard forks. 
 Any user able to deposit the correct amount of `NAM` is able to propose some changes in a proposal for which delegators and validators cast their `yay` or `nay` votes. 
 It is also possible to attach some payloads to proposals, in specific cases, to embed additional information. 
@@ -41,6 +49,7 @@ The signaling mechanism is used for changes which require a hard fork, while the
 Further information about delegators, validators, and NAM can be found in the [economics section](../economics.mdx).
 
 ## Outline
+
 There are two ways to propose a change to the Namada protocol:
 
 1. [**On-chain**](#on-chain-governance) - A proposal is submitted to the Namada blockchain, and the Namada blockchain handles the voting process.
@@ -52,5 +61,3 @@ Namada governance implements a spam resistance mechanism to prevent the network 
 This mechanism is based on the fact that a proposal must be submitted with a deposit of `NAM` tokens.
 This deposit is returned to the proposer if the proposal is accepted, and burned otherwise.
 This is only possible if the proposal is submitted on-chain, as off-chain proposals are not able to submit a deposit.
-
-

--- a/packages/specs/pages/governance/off-chain.mdx
+++ b/packages/specs/pages/governance/off-chain.mdx
@@ -39,7 +39,7 @@ Offline votes are represented as JSON objects with the following structure:
   proposalHash: Base64<Vec<u8>>,
   voter: Address,
   signature: Base64<Self.proposalHash>,
-  vote: Enum(yay|nay)
+  vote: Enum(yay|nay|abstain)
 }
 ```
 

--- a/packages/specs/pages/governance/on-chain.mdx
+++ b/packages/specs/pages/governance/on-chain.mdx
@@ -93,7 +93,7 @@ struct OnChainVote {
     yay: ProposalVote,
 }
 ```
-where `ProposalVote` is an enum representing a `Yay` or `Nay` vote: the yay variant also contains the specific memo (if any) required for that proposal.
+where `ProposalVote` is an enum representing a `Yay`, `Nay`, or `Abstain` vote: the yay variant also contains the specific memo (if any) required for that proposal.
 
 Storage writes for a vote transaction are described [here](./storage.mdx#votes).
 
@@ -122,12 +122,16 @@ Tallying is computed with the following rules:
 
 1. Sum all the voting power of delegates that voted `Yay`, call this sum `SumYay`
 2. Sum all the voting power of delegates that voted `Nay`, call this sum `SumNay`
-3. Check if the sum `SumYay` + `SumNay` meets the first threshold, if not, the proposal outcome is negative
-3. For any delegate that voted `Yay`, subtract the voting power of any delegator that voted `Nay` from `SumYay`
-4. For any delegate that voted `Nay`, subtract the voting power of any delegator that voted `Yay` from `SumNay`
-5. Add voting power for any delegation that voted `Yay` (whose corresponding delegate didn't vote `Yay`) to `SumYay`
-6. Add voting power for any delegation that voted `Nay` (whose corresponding delegate didn't vote `Nay`) to `SumNay`
-7. If the sum `SumYay` is greater than or equal to the sum `SumNay`, **AND** `SumYay` divided by the total `bonded-stake` is greater or equal to the threshold set by `ProposalType`, the proposal outcome is positive, otherwise negative
+3. Sum all the voting power of delegates that voted `Abstain`, call this sum `SumAbstain`
+4. Check if the sum `SumYay` + `SumNay` + `SumAbstain` meets the first threshold, if not, the proposal outcome is negative
+5. For any delegate that voted `Yay`, subtract the voting power of any delegator that voted other than `Yay` from `SumYay`
+6. For any delegate that voted `Nay`, subtract the voting power of any delegator that voted other than `Nay` from `SumNay`
+7. For any delegate that voted `Abstain`, subtract the voting power of any delegator that voted other than `Abstain` from `SumAbstain`
+8. Add voting power for any delegation that voted `Yay` (whose corresponding delegate didn't vote `Yay`) to `SumYay`
+9. Add voting power for any delegation that voted `Nay` (whose corresponding delegate didn't vote `Nay`) to `SumNay`
+9. Add voting power for any delegation that voted `Abstain` (whose corresponding delegate didn't vote `Abstain`) to `SumAbstain`
+10. Set `SumYeaOrNay` to `SumYay` + `SumNay`
+11. Decide whether or not the proposal succeeds based on the proposal-type-specific tally instructions (see [Proposal](./proposal.md))
 
 </Steps>
 

--- a/packages/specs/pages/governance/proposal.mdx
+++ b/packages/specs/pages/governance/proposal.mdx
@@ -59,26 +59,25 @@ pub enum ProposalType {
 - Doesn't carry any WASM code
 - Allows both validators and delegators to vote
 - Requires $\frac{1}{3}$ of the total voting power to vote
-- Requires $\frac{1}{2}$ of the total votes to be `Yay`
+- Requires $\frac{1}{2}$ of the non-abstain (either yea or nay) votes to be `Yay`
 
 `StewardFundingProposal` is a proposal to *conduct* _Public Goods Funding_ **by a steward**:
 - Can only be submitted by PGF stewards
 - Allows both validators and delegators to vote
-- Passes by default **UNLESS** $\frac{1}{3}$ of the total voting power votes on the proposal, **AND** out of the votes, at least $\frac{1}{2}$ are `Nay`
-- Causes the steward to lose steward status if $\frac{2}{3}$ of the total voting power votes on the proposal **AND** out of the votes, at least $\frac{2}{3}$ are `Nay`
+- Passes by default **UNLESS** $\frac{1}{3}$ of the total voting power votes on the proposal, **AND** out of the votes, at least $\frac{1}{2}$ of the non-abstain votes are `Nay`
+- Causes the steward to lose steward status if $\frac{2}{3}$ of the total voting power votes on the proposal **AND** out of the votes, at least $\frac{2}{3}$ of the non-abstain votes are `Nay`
 
 `FundingProposal` is a proposal to *conduct* _Public Goods Funding_ **by anyone**:
 - Allows both validators and delegators to vote
 - Requires $\frac{1}{3}$ of the total voting power to vote
-- Requires $\frac{1}{2}$ of the total votes to be `Yay`
+- Requires $\frac{1}{2}$ of the non-abstain votes to be `Yay`
 
 `PGFProposal` is a specific proposal to propose transfers for _Public Goods Funding_:
 - Doesn't carry any WASM code
 - Allows both validators and delegators to vote
 If the proposer is not a steward:
 - Requires $\frac{1}{3}$ of the total voting power to vote
-- Requires $\frac{1}{2}$ of the total votes to be `Yay`
+- Requires $\frac{1}{2}$ of the non-abstain votes to be `Yay`
 If the proposer is a steward, passes unless:
-- $\frac{1}{3}$ of the total voting power votes on the proposal, **AND** out of the votes, at least $\frac{1}{2}$ are `Nay`
-- Causes the steward to lose steward status if $\frac{2}{3}$ of the total voting power votes on the proposal **AND** out of the votes, at least $\frac{2}{3}$ are `Nay`
-
+- $\frac{1}{3}$ of the total voting power votes on the proposal, **AND** out of the votes, at least $\frac{1}{2}$ of the non-abstain votes are `Nay`
+- Causes the steward to lose steward status if $\frac{2}{3}$ of the total voting power votes on the proposal **AND** out of the votes, at least $\frac{2}{3}$ of the non-abstain votes are `Nay`


### PR DESCRIPTION
Add an `Abstain` vote option, similar to Cosmos. This is definitely necessary now that we don't have separate delegates. Intuitively, `Abstain` means "count me for the quorum, but not for whether or not the proposal should pass".