### PR TITLE
fix: validators hardware reference

### DIFF
--- a/packages/docs/pages/operators/validators/_meta.json
+++ b/packages/docs/pages/operators/validators/_meta.json
@@ -1,5 +1,8 @@
 {
-  "hardware": "Hardware requirements",
+  "hardware": {
+    "title": "Hardware requirements",
+    "href": "/operators/hardware"
+  },
   "genesis-validator-setup": "Genesis validator setup",
   "run-your-genesis-validator": "Running a genesis validator",
   "post-genesis-validator-setup": "Initialising a validator account",


### PR DESCRIPTION
## Issue
Validator Hardware requirements don't work 

##  How to reproduce
Go to https://docs.namada.net/operators/validators# and click on `Hardware requirements`. nothing happened 

## Solution 
We already have a Hardware page with requirements for all types of Nodes. 
https://docs.namada.net/operators/hardware
To avoid duplicate code redirect the user to `Hardware` page