### PR TITLE
Removes duplicated governance proposal types

### DIFF
--- a/packages/specs/pages/governance/proposal.mdx
+++ b/packages/specs/pages/governance/proposal.mdx
@@ -36,15 +36,14 @@ The `ProposalType` imply different combinations of:
 
 ## Supported proposal types
 
-At the moment, Namada supports 5 types of governance proposals:
+At the moment, Namada supports 3 types of governance proposals:
 
 ```rust
 pub enum ProposalType {
   /// Carries the optional proposal code path
   Default(Option<String>),
   StewardProposal,
-  StewardFundingProposal,
-  FundingProposal
+  PGFProposal,
 }
 ```
 
@@ -61,20 +60,10 @@ pub enum ProposalType {
 - Requires $\frac{1}{3}$ of the total voting power to vote
 - Requires $\frac{1}{2}$ of the non-abstain (either yea or nay) votes to be `Yay`
 
-`StewardFundingProposal` is a proposal to *conduct* _Public Goods Funding_ **by a steward**:
-- Can only be submitted by PGF stewards
-- Allows both validators and delegators to vote
-- Passes by default **UNLESS** $\frac{1}{3}$ of the total voting power votes on the proposal, **AND** out of the votes, at least $\frac{1}{2}$ of the non-abstain votes are `Nay`
-- Causes the steward to lose steward status if $\frac{2}{3}$ of the total voting power votes on the proposal **AND** out of the votes, at least $\frac{2}{3}$ of the non-abstain votes are `Nay`
-
-`FundingProposal` is a proposal to *conduct* _Public Goods Funding_ **by anyone**:
-- Allows both validators and delegators to vote
-- Requires $\frac{1}{3}$ of the total voting power to vote
-- Requires $\frac{1}{2}$ of the non-abstain votes to be `Yay`
-
-`PGFProposal` is a specific proposal to propose transfers for _Public Goods Funding_:
+`PGFProposal` is a proposal to *conduct* _Public Goods Funding_:
 - Doesn't carry any WASM code
 - Allows both validators and delegators to vote
+- Has different properties depending on the submitter being a stewards or not
 If the proposer is not a steward:
 - Requires $\frac{1}{3}$ of the total voting power to vote
 - Requires $\frac{1}{2}$ of the non-abstain votes to be `Yay`


### PR DESCRIPTION
This update matches the specs with the actual code. More specifically, we only have one `PGFProposal` variant that encompass both the `StewardFundingProposal` and the `FundingProposal`