### PR TITLE
Update local-network.mdx

### DIFF
--- a/packages/docs/pages/operators/networks/local-network.mdx
+++ b/packages/docs/pages/operators/networks/local-network.mdx
@@ -55,7 +55,7 @@ For example, a MacOS user would run something along the lines of:
 python3 ./scripts/gen_localnet.py \
 --localnet-dir genesis/localnet \
 --mode release # Assuming the binaries were built using `make build-release` \
---parameters '{"parameters": {"max_expected_time_per_block": 10}, "pos_params": {"pipeline_len": "5"}}' 
+--parameters '{"parameters": {"max_expected_time_per_block": 10}, "pos_params": {"pipeline_len": 5}}' 
 # In order to change max_expected_time_per_block to 10 seconds from the default 30, and the pipeline length to 5 epochs from the default 2.
 ```
 


### PR DESCRIPTION
For the example:
Invalid type for 'pos_params.pipeline_len', which should be 'u64' not 'string'.

python3 ./scripts/gen_localnet.py \
--localnet-dir genesis/localnet \
--mode release \
--params '{"parameters": {"max_expected_time_per_block": 10}, "pos_params": {"pipeline_len": "5"}}'

"pipeline_len": "5" -> "pipeline_len": 5