### PR TITLE
Fix genesis-bond script.

### DIFF
--- a/packages/docs/pages/operators/networks/genesis-flow/participants.mdx
+++ b/packages/docs/pages/operators/networks/genesis-flow/participants.mdx
@@ -194,10 +194,10 @@ Please follow the below steps:
 
 ```bash copy
 namadac utils genesis-bond \
-    --validator "<your-validator-alias>" \  # Validator address.
-    --amount "<amount>" \  # Amount of tokens to stake in a bond.
-    --source "<your-tpknam-in-balances.toml>" \  # Source address for delegations. For self-bonds, the validator is also the source.
-    --path "<filename-for-your-tx.toml>"  \  # Output toml file to write transactions to.
+    --validator "<your-validator-address>" \
+    --amount "<amount-to-stake-in-bond>" \
+    --source "<your-tpknam-in-balances.toml>" \
+    --path "<filename-for-your-tx.toml>"
 ```
 
 After this step is completed, sign the transaction 


### PR DESCRIPTION
The `--validator` parameter should specify an address, not an alias.

Additionally, backslash escapes don't work well with comments on the same line, so copy/pasting this into a shell won't work without removing the comments (and the final backslash).