### PR TITLE
Minor improvements and fixes for Namada SDK integration docs

### DIFF
--- a/packages/docs/pages/integrating-with-namada/sdk/constructing-transfers.mdx
+++ b/packages/docs/pages/integrating-with-namada/sdk/constructing-transfers.mdx
@@ -60,21 +60,22 @@ use namada_sdk::{
         TransferTarget,
     },
     masp_primitives::zip32::ExtendedSpendingKey,
-    address::Address,
+    key::common::PublicKey,
 };
 
-// Make sure to replace 'secret-ex' with an actual Namada extended spending key
+// Make sure to replace "secret-ex" with an actual Namada extended spending key
 let source = ExtendedSpendingKey::from_str("secret-ex").unwrap();
 // Make sure to replace "payment-addr-ex" with an actual Namada payment address
 let destination = PaymentAddress::from_str("payment-addr-ex").unwrap();
-let fee_payer = 
+// Make sure to replace "public-key" with an actual Namada public key
+let fee_payer = PublicKey::from_str("public-key");
+let amount = /* Needed amount here */;
 let mut transfer_tx_builder = namada
         .new_transfer(
-            TransferSource::ExtendedSpendingKey(source),
-            TransferTarget::Address(Address::from(&destination.public_key)),
+            TransferSource::ExtendedSpendingKey(source.into()),
+            TransferTarget::PaymentAddress(destination),
             namada.native_token(),
             amount,
         )
-        // Make sure to replace "transparent-address-ex" with an actual Namada transparent address
-        .signing_keys(vec![Address::from_str("transparent-address-ex").ok()]);
+        .signing_keys(vec![fee_payer]);
 ```

--- a/packages/docs/pages/integrating-with-namada/sdk/constructing-transfers.mdx
+++ b/packages/docs/pages/integrating-with-namada/sdk/constructing-transfers.mdx
@@ -52,8 +52,16 @@ In order to make the transfer shielded, we need to the only difference is to use
 It is important to use the shielded extended `SpendingKey` as the source.
 
 ```rust
-
-use namada::types::masp::{ExtendedSpendingKey, PaymentAddress, TransferSource, TransferTarget};
+use std::str::FromStr;
+use namada_sdk::{
+    masp::{
+        PaymentAddress,
+        TransferSource,
+        TransferTarget,
+    },
+    masp_primitives::zip32::ExtendedSpendingKey,
+    address::Address,
+};
 
 // Make sure to replace 'secret-ex' with an actual Namada extended spending key
 let source = ExtendedSpendingKey::from_str("secret-ex").unwrap();

--- a/packages/docs/pages/integrating-with-namada/sdk/generating-accounts.mdx
+++ b/packages/docs/pages/integrating-with-namada/sdk/generating-accounts.mdx
@@ -4,7 +4,7 @@
 Representing accounts using the Namada SDK is straightforward. An account on Namada is defined by its public key(s) and private key(s) (plural for multisignatures). The public key(s) is/are used to identify the account and the private key is used to sign transactions. In the below snippet, we represent the account using the public key and private key.
 
 ```rust
-use namada_sdk::types::key::common::{PublicKey, SecretKey};
+use namada_sdk::key::common::{PublicKey, SecretKey};
 struct SimpleAccount {
     public_key: PublicKey,
     private_key: SecretKey
@@ -14,7 +14,7 @@ struct SimpleAccount {
 For a multisignature account, we can represent this through a vector of keys.
 
 ```rust
-use namada_sdk::types::key::common::{PublicKey, SecretKey};
+use namada_sdk::key::common::{PublicKey, SecretKey};
 struct MultisigAccount {
     public_keys: Vec<PublicKey>,
     private_keys: Vec<SecretKey>
@@ -24,7 +24,7 @@ struct MultisigAccount {
 Multisignature accounts, because they are initialized by an on-chain transaction, will always have their public key revealed to the ledger. However, when keypairs are generated in an offline fashion, the user must submit a transaction in order to reveal their public key. Because of this, it is helpful to add the field `revealed` to the account struct.
 
 ```rust
-use namada_sdk::types::key::common::{PublicKey, SecretKey};
+use namada_sdk::key::common::{PublicKey, SecretKey};
 struct Account {
     public_key: PublicKey,
     private_key: SecretKey,
@@ -39,7 +39,7 @@ In order to reveal the public key of an implicit account, the user must submit a
 ```rust
 use namada_sdk::io::NullIo;
 use namada_sdk::NamadaImpl;
-use namada_sdk::types::chain::ChainId;
+use namada_sdk::chain::ChainId;
 
 
 // Define the namada implementation (assuming we have a wallet, http_client, and shielded_ctx)

--- a/packages/docs/pages/integrating-with-namada/sdk/governance.mdx
+++ b/packages/docs/pages/integrating-with-namada/sdk/governance.mdx
@@ -82,7 +82,9 @@ In order to vote on a proposal, we need a valid proposal id. We can retrieve the
 Once we have the proposal id, we can vote on the proposal using the following code:
 
 ```rust
-    let proposal_id = 1 as u64 // placeholder, replace with actual proposal id
+    use namada_sdk::signing::default_sign;
+
+    let proposal_id = 1 as u64; // placeholder, replace with actual proposal id
     let vote = String::from("Yay");
     let signing_public_key = signing_key.to_public();
 

--- a/packages/docs/pages/integrating-with-namada/sdk/proof-of-stake.mdx
+++ b/packages/docs/pages/integrating-with-namada/sdk/proof-of-stake.mdx
@@ -9,10 +9,9 @@ The `namada_impl` object is assumed to have been constructed as described in the
 </Callout>
 
 ```rust 
-// We assume we have a namada_impl object that is already initialized
+// We assume we have a namada object that is already initialized
 
-let bond_tx_builder = namada_impl
-            
+let bond_tx_builder = namada            
             .new_bond(validator_address.clone(), amount)
             .source(source_address.clone())
             .signing_keys(vec![source_public_key]);
@@ -22,7 +21,7 @@ let (mut bond_tx, signing_data) = bond_tx_builder
     .await
     .expect("unable to build bond");
 
-namada_impl
+namada
     .sign(
         &mut bond_tx,
         &bond_tx_builder.tx,

--- a/packages/docs/pages/integrating-with-namada/sdk/proof-of-stake.mdx
+++ b/packages/docs/pages/integrating-with-namada/sdk/proof-of-stake.mdx
@@ -9,8 +9,9 @@ The `namada_impl` object is assumed to have been constructed as described in the
 </Callout>
 
 ```rust 
-// We assume we have a namada object that is already initialized
+use namada_sdk::signing::default_sign;
 
+// We assume we have a namada object that is already initialized
 let bond_tx_builder = namada            
             .new_bond(validator_address.clone(), amount)
             .source(source_address.clone())

--- a/packages/docs/pages/integrating-with-namada/sdk/setting-up-a-client.mdx
+++ b/packages/docs/pages/integrating-with-namada/sdk/setting-up-a-client.mdx
@@ -101,7 +101,7 @@ This client will allow us to make asynchronous calls to the network and handle t
 
 ## Instantiating a Namada Implementation object
 
-When constructing transactions using the sdk, we almost alwasy need a `namada_impl` object. 
+When constructing transactions using the sdk, we almost alwasy need a `namada` object. 
 
 ```rust
 use namada_sdk::NamadaImpl; // This module allows us to access the NamadaImpl struct, which is needed for most transactions

--- a/packages/docs/pages/integrating-with-namada/sdk/setting-up-a-client.mdx
+++ b/packages/docs/pages/integrating-with-namada/sdk/setting-up-a-client.mdx
@@ -111,10 +111,10 @@ let http_client = reqwest::Client::new();
 let wallet = Wallet::from_mnemonic("your mnemonic here").unwrap();
 let wallet: namada_sdk::wallet::Wallet<FsWalletUtils> = FsWalletUtils::new(PathBuf::from("wallet.toml"));
 let shielded_ctx = FsShieldedUtils::new(Path::new("masp/").to_path_buf());
-let namada_impl = NamadaImpl::new(http_client, wallet, shielded_ctx, NullIo)
+let namada = NamadaImpl::new(http_client, wallet, shielded_ctx, NullIo)
         .await
         .expect("unable to construct Namada object")
         .chain_id(ChainId::from_str(CHAIN_ID).unwrap());
 ```
 
-This object will be referenced throughout the documentation as `namada_impl`.
+This object will be referenced throughout the documentation as `namada`.

--- a/packages/docs/pages/integrating-with-namada/sdk/setting-up-a-wallet.mdx
+++ b/packages/docs/pages/integrating-with-namada/sdk/setting-up-a-wallet.mdx
@@ -61,16 +61,15 @@ In the second part of the above function, the key is derived from the mnemonic p
 It is also possible to create the sdk wallet from scratch. This is more involved because it requires generating a new store for the wallet to exist in.
 
 ```rust
-use std::path::PathBuf;
-
-use namada::{
-    sdk::wallet::{
-        alias::Alias, ConfirmationResponse, GenRestoreKeyError, Store, StoredKeypair, Wallet,
-        WalletUtils,
+use namada_sdk::{
+    wallet::{
+        Store,
+        StoredKeypair,
+        Wallet,
+        WalletIo,
     },
-    types::{
-        address::Address,
-        key::{common::SecretKey, PublicKeyHash},
+    address::Address,
+    key::{common::SecretKey, PublicKeyHash},
     },
 };
 use rand::rngs::OsRng;
@@ -82,7 +81,7 @@ pub struct SdkWallet {
 impl SdkWallet {
     pub fn new(sk: SecretKey, nam_address: Address) -> Self {
         let store = Store::default();
-        let mut wallet = Wallet::new(PathBuf::new(), store);
+        let mut wallet = Wallet::new(SdkWalletUtils {}, store);
         let stored_keypair = StoredKeypair::Raw(sk.clone());
         let pk_hash = PublicKeyHash::from(&sk.to_public());
         let alias = "alice".to_string();
@@ -94,37 +93,19 @@ impl SdkWallet {
 
 pub struct SdkWalletUtils {}
 
-impl WalletUtils for SdkWalletUtils {
-    type Storage = PathBuf;
-
+impl WalletIo for SdkWalletUtils {
     type Rng = OsRng;
+}
 
-    fn read_decryption_password() -> zeroize::Zeroizing<std::string::String> {
-        panic!("attempted to prompt for password in non-interactive mode");
+impl Clone for SdkWalletUtils {
+    fn clone(&self) -> Self {
+        SdkWalletUtils::new()
     }
+}
 
-    fn read_encryption_password() -> zeroize::Zeroizing<std::string::String> {
-        panic!("attempted to prompt for password in non-interactive mode");
-    }
-
-    fn read_alias(_prompt_msg: &str) -> std::string::String {
-        panic!("attempted to prompt for alias in non-interactive mode");
-    }
-
-    fn read_mnemonic_code() -> std::result::Result<namada::bip39::Mnemonic, GenRestoreKeyError> {
-        panic!("attempted to prompt for mnemonic in non-interactive mode");
-    }
-
-    fn read_mnemonic_passphrase(_confirm: bool) -> zeroize::Zeroizing<std::string::String> {
-        panic!("attempted to prompt for mnemonic in non-interactive mode");
-    }
-
-    fn show_overwrite_confirmation(
-        _alias: &Alias,
-        _alias_for: &str,
-    ) -> namada::sdk::wallet::store::ConfirmationResponse {
-        // Automatically replace aliases in non-interactive mode
-        ConfirmationResponse::Replace
+impl SdkWalletUtils {
+    fn new() -> Self {
+        Self {}
     }
 }
 ```

--- a/packages/docs/pages/integrating-with-namada/sdk/setting-up-a-wallet.mdx
+++ b/packages/docs/pages/integrating-with-namada/sdk/setting-up-a-wallet.mdx
@@ -25,6 +25,8 @@ use namada_sdk::wallet::fs::FsWalletUtils;
 The SDK can create a wallet from a mnemonic phrase. The mnemonic phrase is a 24 word phrase that can be used to restore a wallet. 
 
 ```rust
+use namada_sdk::bip39::Mnemonic;
+
 let mnemonic = Mnemonic::from_phrase(MNEMONIC_CODE, namada_sdk::bip39::Language::English)
 ```
 

--- a/packages/docs/pages/integrating-with-namada/sdk/setting-up-a-wallet.mdx
+++ b/packages/docs/pages/integrating-with-namada/sdk/setting-up-a-wallet.mdx
@@ -14,8 +14,8 @@ use namada_sdk::NamadaImpl;
 
 ```rust
 // SecretKey, common and SchemeType give access to Namada cryptographic keys and their relevant implementations. Namada supports ED25519 and SECP256K1 keys.
-use namada_sdk::types::key::common::SecretKey;
-use namada_sdk::types::key::{common, SchemeType};
+use namada_sdk::key::common::SecretKey;
+use namada_sdk::key::{common, SchemeType};
 // Filesystem wallet utilities (stores the path of the wallet on the filesystem)
 use namada_sdk::wallet::fs::FsWalletUtils;
 ```


### PR DESCRIPTION
One major improvement is that I changed the standard name for a NamadaImpl instance from namada_impl to namada, as the latter was used more in docs, with only one file (not including https://github.com/anoma/namada-docs/blob/master/packages/docs/pages/integrating-with-namada/sdk/setting-up-a-client.mdx) using namada_impl name and others using namada.
Also added some imports in places where they might create confusion and fixed imports using outdated "types" crate.