### PR TITLE
Error in PGF proposal requirements

### DIFF
--- a/packages/specs/pages/modules/governance/public-goods-funding/funding.mdx
+++ b/packages/specs/pages/modules/governance/public-goods-funding/funding.mdx
@@ -79,7 +79,7 @@ For blocks of which both RPGF and CPGF funding is to be applied, RPGF is applied
 There is also the possibility to propose funding as a non-PGF steward. This is done by submitting the custom governance proposal `FundingProposal` through governance.
 The structure of the proposal is identical to the `StewardFundingProposal` except that the author of the proposal is not required to be a PGF steward, and the voting conditions differ.
 The proposal will be such that it **is rejected** by default **unless** the following conditions are met:
-  - $\frac{2}{3}$ of voting-power must vote on the `FundingProposal` 
+  - $\frac{1}{3}$ of voting-power must vote on the `FundingProposal` 
   - More than half of the votes must be in favor of the `FundingProposal`
 
 Note that these are the same voting conditions as the `StewardProposal`


### PR DESCRIPTION
According to my email, which has still not been viewed, you either have an error in the documentation or in the protocol itself.

There are two places in the Specs that specify the requirements for PGF-proposal, if author is not a steward:
- https://github.com/anoma/namada-docs/blob/059c452ee74299b6dbc939784d39854cbdd91a6f/packages/specs/pages/modules/governance/proposal.mdx?plain=1#L82
- https://github.com/anoma/namada-docs/blob/059c452ee74299b6dbc939784d39854cbdd91a6f/packages/specs/pages/modules/governance/public-goods-funding/funding.mdx?plain=1#L82

They contain different information regarging total voting power. If 1/3 is still the correct one, than it should be updated in the second place