### PR TITLE
Add base dir callout for local network

### DIFF
--- a/packages/docs/pages/operators/networks/local-network.mdx
+++ b/packages/docs/pages/operators/networks/local-network.mdx
@@ -1,4 +1,5 @@
 import Expandable from "../../../components/Expandable";
+import { Callout } from "nextra-theme-docs";
 
 # Spinning up a local network
 
@@ -71,6 +72,18 @@ The ledger can be run through the familiar command:
 ```shell
 ./target/release/namada ledger # Assuming the binaries were built using `make build-release`
 ```
+
+<Callout>
+If you receive the error `Failed to construct Namada chain context...` you need to set the variable `NAMADA_BASE_DIR`
+
+```shell
+export NAMADA_BASE_DIR=/$(pwd)/.namada/validator-0
+
+# or pass it as the parameter --base-dir
+./target/release/namada ledger --base-dir="/$(pwd)/.namada/validator-0"
+```
+
+</Callout>
 
 ## Cleaning up
 

--- a/packages/docs/pages/operators/networks/local-network.mdx
+++ b/packages/docs/pages/operators/networks/local-network.mdx
@@ -74,7 +74,7 @@ The ledger can be run through the familiar command:
 ```
 
 <Callout>
-If you receive the error `Failed to construct Namada chain context...` you need to set the variable `NAMADA_BASE_DIR`
+If you receive the error `Failed to construct Namada chain context...`, then you need to set the variable `NAMADA_BASE_DIR`. For example:
 
 ```shell
 export NAMADA_BASE_DIR=/$(pwd)/.namada/validator-0


### PR DESCRIPTION
When running a local network, you should have set `NAMADA_BASE_DIR` or pass the `--base-dir` parameter.

It was missing here https://docs.namada.net/operators/networks/local-network 