### PR TITLE
MASP address in shielded actions

### DIFF
--- a/packages/docs/pages/users/ibc/shielded-ibc.mdx
+++ b/packages/docs/pages/users/ibc/shielded-ibc.mdx
@@ -22,28 +22,21 @@ It is no longer necessary to manually generate the MASP proof, and the `ibc-gen-
 </Callout>
 
 IBC transfers to a shielded address work similarly to those for a [tranparent address](./transparent-ibc.mdx), 
-the only difference being that we provide for `$RECV_ADDRESS` a shielded (`znam`) address instead of a transparent (`tnam`) one:
-
-```bash copy
-namadac ibc-transfer \
-  --source $SOURCE_ADDRESS \
-  --receiver $RECEIVER_PAYMENT_ADDRESS \
-  --token $TOKEN \
-  --amount $AMOUNT \
-  --channel-id $CHANNEL_ID
-```
-  
-Or, when sending from a Cosmos Sdk chain:
+the only difference being that we provide for `$RECV_ADDRESS` the internal address of MASP:
 
 ```bash copy
 gaiad tx ibc-transfer transfer \
   $CHANNEL_ID \
-  $RECEIVER_PAYMENT_ADDRESS \
+  $MASP_ADDRESS \
   ${AMOUNT}${IBC_TOKEN_ADDRESS} \
   --from $COSMOS_ALIAS \
   --node $COSMOS_RPC_ENDPOINT \
   --fees 5000uatom
 ```
+
+<Callout>
+The previous command would work even with `$RECEIVER_PAYMENT_ADDRESS` as the second argument but it is highly recommended to stick to `$MASP_ADDRESS` for privacy reasons.
+</Callout>
 
 ## IBC transfer from a shielded address
 You can also send IBC transfers from a shielded address, by providing the associated spending key as the source:

--- a/packages/docs/pages/users/ibc/shielded-ibc.mdx
+++ b/packages/docs/pages/users/ibc/shielded-ibc.mdx
@@ -22,7 +22,7 @@ It is no longer necessary to manually generate the MASP proof, and the `ibc-gen-
 </Callout>
 
 IBC transfers to a shielded address work similarly to those for a [tranparent address](./transparent-ibc.mdx), 
-the only difference being that we provide for `$RECV_ADDRESS` the internal address of MASP:
+the only difference being that we provide the MASP internal address as the value instead of `$RECV_ADDRESS`:
 
 ```bash copy
 gaiad tx ibc-transfer transfer \
@@ -35,7 +35,7 @@ gaiad tx ibc-transfer transfer \
 ```
 
 <Callout>
-The previous command would work even with `$RECEIVER_PAYMENT_ADDRESS` as the second argument but it is highly recommended to stick to `$MASP_ADDRESS` for privacy reasons.
+The previous command would work even with `$RECEIVER_PAYMENT_ADDRESS` as the second argument, but it is highly recommended to use `$MASP_ADDRESS` to preserve privacy.
 </Callout>
 
 ## IBC transfer from a shielded address


### PR DESCRIPTION
Updates the shielded IBC docs to suggest using the internal `MASP` address instead of the payment address as the receiver. Also removes the Namada2Namada example since we don't expect it to be any useful. 