### PR TITLE
docs: fix gaia ibc transfer command

### DIFF
--- a/packages/docs/pages/users/ibc/transparent-ibc.mdx
+++ b/packages/docs/pages/users/ibc/transparent-ibc.mdx
@@ -56,7 +56,6 @@ of the counterparty chain when in doubt.
 
 ```bash
 gaiad tx ibc-transfer transfer \
-  transfer \
   channel-64 \
   tnam1qzgmrvz0zdjtgdu7yq6hl46wdg7za2t2hg5t85c7 \
   10000000uatom \


### PR DESCRIPTION
The gaia ibc transfer command is not correct, use this change to fix it.