### PR TITLE
Update fee docs

### DIFF
--- a/packages/docs/pages/users/fees.mdx
+++ b/packages/docs/pages/users/fees.mdx
@@ -126,7 +126,7 @@ This **might** incentivise validators to prioritise this transaction above those
 It is also possible to pay for fees using the MASP when dealing with a transaction involving shielded inputs (shielded and unshielding transfers both natively and over IBC).
 This is a good practice when trying to maximize data protection and minimize information leakage.
 
-When dealing with MASP fee payment, the client will first try to deduct the fees from the spending key specfied by `--gas-spending-key` of the shielded transaction and unshield them to the transparent balance of the `--gas-payer` (or the address corresponding to the first key in the `--signing-keys`).
+When dealing with MASP fee payment, the client will first try to deduct the fees from the `--source` spending key of the shielded transaction and unshield them to the transparent balance of the `--gas-payer` (or the address corresponding to the first key in the `--signing-keys`).
 Then, these fees are paid to the block proposer from the gas payer.
 
 For example, if the user has a spending key `spending-key-1` in their wallet, and they want to pay for the fees of a shielded transfer transaction using the MASP, they would run the following command:
@@ -138,10 +138,9 @@ namadac transfer \
   --token OSMO \
   --amount 10 \
   --gas-payer my-implicit \
-  --gas-spending-key spending-key-1
 ```
 
-If `spending-key-1` does not have enough balance or the user simply wants to use a separate key for gas, they can specify a different spending key for fee payment:
+If `spending-key-1` does not have enough balance or the user simply wants to use a separate key for gas, they can specify a different spending key for fee payment using the `--gas-spending-key` argument:
 
 ```shell copy 
 namadac transfer \
@@ -165,8 +164,8 @@ For an atomic batch, the masp fee payment transaction (the first one in the batc
 
 It is also possible to use a disposable gas payer to pay for transaction fees.
 This is useful (and recommended) in cases where the user does not want to leak information and reveal the identity of the `--gas-payer`.
-In order to use a disposable gas payer, the user must include the `--disposable-gas-payer` flag.
-The fees will be deducted from the shielded balance of the shielded transactions `--gas-spending-key` and unshielded to the transparent balance of an ephemeral transparent address before being paid by the ephemeral address.
+The disposable gas payer is the default option and it's used all the times unless `--gas-payer` is specified.
+The fees will be deducted from the shielded balance of the shielded transaction's `--source` or `--gas-spending-key` and unshielded to the transparent balance of an ephemeral transparent address before being paid by the ephemeral address.
 
 For example, if the user has the same two spending keys from the previous example in their wallet, and they want to pay for the fees of an unshield transaction using a disposable address, they would run the following command:
 
@@ -177,7 +176,6 @@ namadac unshield \
   --token OSMO \
   --amount 10 \
   --gas-spending-key spending-key-2 \
-  --disposable-gas-payer
 ```
 
 ### MASP fee payment gas limit


### PR DESCRIPTION
Depends on https://github.com/anoma/namada/pull/4619.

Updates the fee docs for the new implicit `--disposable-gas-payer` and the implied `--gas-spending-key`.